### PR TITLE
Add support to multiple instances

### DIFF
--- a/src/jquery.fadeshow-0.1.1.js
+++ b/src/jquery.fadeshow-0.1.1.js
@@ -34,11 +34,11 @@
 		function init()
 		{
 			$thisElement.append("<div class='fadeShow-container'></div>"); //add the container to the element
-			
+
 			$.each(settings.images, function(count){
 				$(".fadeShow-container", $thisElement).append(format(this, count)); //format the image urls and place them inside the container
 				
-				var $imageElement = $("#fadeShow-slide"+count); //get the object
+				var $imageElement = $thisElement.find(".fadeShow-slide"+count); //get the object
 				
 				$imageElements.push($imageElement); //add it to the array of elements
 			});
@@ -97,7 +97,7 @@
 		function format(image, count)
 		{
 			//using the background-image, but adding the image element so we can get the aspect ratio
-			return "<div class='image' id='fadeShow-slide"+count+"' style='background-image: url("+image+");'><img src='"+image+"' alt='' /></div>";
+			return "<div class='image fadeShow-slide"+count+"' style='background-image: url("+image+");'><img src='"+image+"' alt='' /></div>";
 		}
 		
 		//display the next image in the array
@@ -105,10 +105,12 @@
 		{
 			//loop through all image elements
 			$.each($imageElements, function(count){
+
 				if(currentSlide == count){
 					setImageRatio(this);
-					
+
 					$(this).addClass('active').removeClass('inactive'); //toggle active class
+
 				} else{
 					$(this).removeClass('active').addClass('inactive'); //toggle inactive class 
 				}


### PR DESCRIPTION
The plugin works perfectly, but using IDs and counts (0, 1, 2, ...) makes this inflexible - for example, if you run more than one instance per page, it'll break - because two IDs fadeShow-slide0 will be created.

I modified the code a bit to use classes and point to elements inside the container, instead looking globally. This way, we can have as many instances as we want inside one page.

PS.: I didn't have the time to compile the minified versions, sorry for that!

Fix for this issue: https://github.com/terwanerik/FadeShow/issues/2
